### PR TITLE
Support rails_relative_url_root in redirect_uri

### DIFF
--- a/modules/openid_connect/lib/open_project/openid_connect/engine.rb
+++ b/modules/openid_connect/lib/open_project/openid_connect/engine.rb
@@ -45,7 +45,7 @@ module OpenProject::OpenIDConnect
 
       strategy :openid_connect do
         # update base redirect URI in case settings changed
-        Providers.configure base_redirect_uri: "#{Setting.protocol}://#{Setting.host_name}"
+        Providers.configure base_redirect_uri: "#{Setting.protocol}://#{Setting.host_name}#{OpenProject::Configuration['rails_relative_url_root']}"
         Providers.load(configuration).map(&:to_h)
       end
     end


### PR DESCRIPTION
Currently, the openid_connect module is not taking in account rails_relative_url_root parameter in the redirect_uri. This PR fixes the issue